### PR TITLE
Please let me know what you think of this fix for a severe bug I had (using html label)

### DIFF
--- a/facebox.js
+++ b/facebox.js
@@ -261,7 +261,14 @@
       var target = href.replace(url,'')
       if (target == '#') return
       $.facebox.reveal($(target).html(), klass)
-
+      $(target).find('[id]').each(function(intIndex) {
+        $(this).attr('id', $(this).attr('id') + '_facebox_active')
+      })
+      $(document).bind('close.facebox', function() {
+        $(target).find('[id]').each(function(intIndex) {
+          $(this).attr('id', $(this).attr('id').replace(/_facebox_active/, ''))
+        })
+      })
     // image
     } else if (href.match($.facebox.settings.imageTypesRegexp)) {
       fillFaceboxFromImage(href, klass)


### PR DESCRIPTION
I was using a `label` element in a form inside a facebox, and clicking on the label would do nothing. This happens only when using the `fillFaceboxFromHref` method. Have a look at my commit note for more details.
