### PR TITLE
Set the dataType to 'script'

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -260,7 +260,7 @@
   }
 
   function fillFaceboxFromAjax(href, klass) {
-    $.get(href, function(data) { $.facebox.reveal(data, klass) })
+    $.get(href, function(data) { $.facebox.reveal(data, klass) }, 'script')
   }
 
   function skipOverlay() {


### PR DESCRIPTION
Seems that the rails responder treats the ajax request as straight html unless this is specified.

Cheers!
