### PR TITLE
Fix for image links with a query string

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -172,7 +172,7 @@
     makeCompatible()
 
     var imageTypes = $.facebox.settings.imageTypes.join('|')
-    $.facebox.settings.imageTypesRegexp = new RegExp('\.(' + imageTypes + ')$', 'i')
+    $.facebox.settings.imageTypesRegexp = new RegExp('\.(' + imageTypes + ')\?', 'i')
 
     if (settings) $.extend($.facebox.settings, settings)
     $('body').append($.facebox.settings.faceboxHtml)


### PR DESCRIPTION
In my commit image links with a query string are displayed correctly (as an image). 

That means you can use link like this: images/file.png?18775769 and it will be handled as image, not as remote file.
