### PR TITLE
Fix for image links with a query string

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -172,7 +172,7 @@
     makeCompatible()
 
     var imageTypes = $.facebox.settings.imageTypes.join('|')
-    $.facebox.settings.imageTypesRegexp = new RegExp('\.(' + imageTypes + ')$', 'i')
+    $.facebox.settings.imageTypesRegexp = new RegExp('\.(' + imageTypes + ')\?', 'i')
 
     if (settings) $.extend($.facebox.settings, settings)
     $('body').append($.facebox.settings.faceboxHtml)

--- a/src/facebox.js
+++ b/src/facebox.js
@@ -172,7 +172,7 @@
     makeCompatible()
 
     var imageTypes = $.facebox.settings.imageTypes.join('|')
-    $.facebox.settings.imageTypesRegexp = new RegExp('\.(' + imageTypes + ')\?', 'i')
+    $.facebox.settings.imageTypesRegexp = new RegExp('\.(' + imageTypes + ')($|\\?)', 'i')
 
     if (settings) $.extend($.facebox.settings, settings)
     $('body').append($.facebox.settings.faceboxHtml)


### PR DESCRIPTION
Now it works for both - links with and without query string (which I forgot about in my previous commit).

So for images you can also use link like this: images/file.png?18775769 and it will be handled correctly as image, not as remote file.
