### PR TITLE
Fix for box not being centered properly

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -124,7 +124,7 @@
       $('#facebox .content').append(data)
       $('#facebox .loading').remove()
       $('#facebox .body').children().fadeIn('normal')
-      $('#facebox').css('left', $(window).width() / 2 - ($('#facebox .popup').width() / 2))
+      $('#facebox').css('left', $(window).width() / 2 - ($('#facebox .popup').outerWidth() / 2))
       $(document).trigger('reveal.facebox').trigger('afterReveal.facebox')
     },
 


### PR DESCRIPTION
I noticed that the boxes were not being centered properly, but always too much to the left. This was caused by the box positioning not taking into account the border and padding of the popup class.

Attached to this request you can find a fix for this problem using jQuery's outerWidth function, which returns the width of the object including border and padding.
