### PR TITLE
Fix 404 with customized close image

### DIFF
--- a/src/facebox.css
+++ b/src/facebox.css
@@ -40,12 +40,10 @@
   top:5px;
   right:5px;
   padding:2px;
-  background:#fff;
-}
-#facebox .close img{
+  background:#fff center center no-repeat;
   opacity:0.3;
 }
-#facebox .close:hover img{
+#facebox .close:hover{
   opacity:1.0;
 }
 

--- a/src/facebox.js
+++ b/src/facebox.js
@@ -92,7 +92,7 @@
       <div class="popup"> \
         <div class="content"> \
         </div> \
-        <a href="#" class="close"><img src="/facebox/closelabel.png" title="close" class="close_image" /></a> \
+        <a href="#" class="close"></a> \
       </div> \
     </div>'
     },
@@ -177,6 +177,12 @@
     $('body').append($.facebox.settings.faceboxHtml)
 
     var preload = [ new Image(), new Image() ]
+    $(preload[0]).bind("load", function() {
+      $('#facebox .close').css({ backgroundImage: "url(" + this.src + ")",
+                                 height:          this.height,
+                                 width:           this.width })
+    })
+
     preload[0].src = $.facebox.settings.closeImage
     preload[1].src = $.facebox.settings.loadingImage
 
@@ -186,7 +192,6 @@
     })
 
     $('#facebox .close').click($.facebox.close)
-    $('#facebox .close_image').attr('src', $.facebox.settings.closeImage)
   }
 
   // getPageScroll() by quirksmode.com


### PR DESCRIPTION
Because the close image is added to the page before the source is updated, an extra request is made which ends up 404ing if the image doesn't exist at /facebox/closelabel.png. This probably doesn't matter, except I noticed over SSL Firefox makes a request for the asset over HTTP and then yells about "unauthenticated content".

I changed `$.facebox.settings.closeImage` from an IMG to background on the link as that made sense for our specific use case. I can see how this may be a backwards incompatible change so I don't mind making another commit that fixes the bug and keeps the IMG. I figured I'd send the patch as-is first and go from there.
