### PR TITLE
Missed method afterClose.facebox

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Facebox also has a bunch of other hooks:
 * `beforeReveal.facebox`
 * `reveal.facebox` (aliased as `afterReveal.facebox`)
 * `init.facebox`
+* `afterClose.facebox`  (callback after closing `facebox`)
 
 Simply bind a function to any of these hooks:
 


### PR DESCRIPTION
Wasn't informed properly in Readme, so I include it 
