### PR TITLE
Better fallback for fillFaceboxFromAjax when fetching fails (e.g. for 404's)

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -260,7 +260,19 @@
   }
 
   function fillFaceboxFromAjax(href, klass) {
-    $.get(href, function(data) { $.facebox.reveal(data, klass) })
+        $.ajax({
+            type: "GET",
+            url: href,
+            success: function (data) {
+                $.facebox.reveal(data, klass)
+            },
+            error: function (xhr, ajaxOptions, thrownError) {
+                data = 'Error: ' + xhr.statusText;
+                
+                $.facebox.reveal(data, klass)
+                return false
+            }
+        })
   }
 
   function skipOverlay() {


### PR DESCRIPTION
Updated fillFaceboxFromAjax to actually use $.ajax in order to get a nicer fallback when fetching fails.
