### PR TITLE
Allow overrides to fillFaceboxFrom* behavior via $.facebox.fillFrom*

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -261,7 +261,7 @@
 
     $.facebox.init(settings)
 
-    function clickHandler() {
+    return this.bind('click.facebox', function() {
       $.facebox.loading(true)
 
       // support for rel="facebox.inline_popup" syntax, to add a class
@@ -271,9 +271,7 @@
 
       $.facebox.fillFromHref(this.href, klass, {})
       return false
-    }
-
-    return this.bind('click.facebox', clickHandler)
+    })
   }
 
   /*


### PR DESCRIPTION
Improve customizability by moving the private fillFaceboxFrom* functions onto the $.facebox object as $.facebox.fillFrom*.  E.g., you can now override $.facebox.fillFromAjax to customize your AJAX calls.

Previously private function which are now available on $.facebox: init, fillFromAjax, fillFromImage, fillFromHref

Previously private functions which remain private:
As inner functions: showOverlay, getPageHeight, getPageScroll, makeCompatible
As local to the closure: hideOverlay

In $.facebox, I pass the full first data argument to the fillFrom\* functions, to allow people to use and process additional arguments on the call side as well.

This addresses pull request #26 and #11 by given people the hooks they need to customize behavior to suit their apps.
