### PR TITLE
Allowing content to be Facebox'd more than once during a single pageview

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -101,6 +101,8 @@
       init()
       if ($('#facebox .loading').length == 1) return true
       showOverlay()
+      
+      $("body").append( $("#facebox .content *:first").remove().hide() );
 
       $('#facebox .content').empty().
         append('<div class="loading"><img src="'+$.facebox.settings.loadingImage+'"/></div>')


### PR DESCRIPTION
When showing a new facebox dialog, move any previously facebox'd content out of the facebox instead of deleting it outright so it can be facebox'd again.
