### PR TITLE
You're only able to extend/override $.facebox.settings by using the $.fn.

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -67,7 +67,7 @@
  */
 (function($) {
   $.facebox = function(data, klass) {
-    $.facebox.loading()
+    $.facebox.loading(data.settings || [])
 
     if (data.ajax) fillFaceboxFromAjax(data.ajax, klass)
     else if (data.image) fillFaceboxFromImage(data.image, klass)


### PR DESCRIPTION
You're only able to extend/override $.facebox.settings by using the $.fn.facebox method, however you're unable to do so using the $.facebox(..) method. This fix lets you do just that.
