### PR TITLE
New setting: overlayClose, stops clicks on overlay from closing facebox

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -84,6 +84,7 @@
     settings: {
       opacity      : 0.2,
       overlay      : true,
+      overlayClose : true, // if false, clicking overlay does not close facebox
       loadingImage : '/facebox/loading.gif',
       closeImage   : '/facebox/closelabel.png',
       imageTypes   : [ 'png', 'jpg', 'jpeg', 'gif' ],
@@ -275,7 +276,7 @@
 
     $('#facebox_overlay').hide().addClass("facebox_overlayBG")
       .css('opacity', $.facebox.settings.opacity)
-      .click(function() { $(document).trigger('close.facebox') })
+      .click(function() { if ($.facebox.settings.overlayClose) $(document).trigger('close.facebox') })
       .fadeIn(200)
     return false
   }


### PR DESCRIPTION
Setting "overlayClose" to false in facebox's settings will cause clicks
on the grey overlay not to close facebox. The default value is true.

overlayClose might not be the best name, but the idea is there.
