### PR TITLE
Allow usage of links with hash to reveal facebox on pages with parameters such as /index.php?id=123

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -237,9 +237,8 @@
   function fillFaceboxFromHref(href, klass) {
     // div
     if (href.match(/#/)) {
-      var url    = window.location.href.split('#')[0]
-      var target = href.replace(url,'')
-      if (target == '#') return
+      var target = href.substring(href.indexOf('#'));
+      if (target == '') return
       $.facebox.reveal($(target).html(), klass)
 
     // image


### PR DESCRIPTION
Allow usage of links with hash to reveal facebox on pages with parameters such as /index.php?id=123. Without this patch facebox would show up empty because the current URL replacement in target href is not done as epxected, thus no data to be shown are found.
