### PR TITLE
Double bind make multiple facebox content rendered when it show up

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -152,7 +152,7 @@
       fillFaceboxFromHref(this.href, klass)
       return false
     }
-
+    this.unbind('click.facebox');
     return this.bind('click.facebox', clickHandler)
   }
 


### PR DESCRIPTION
When the facebox got initialize multiple times, such as in the page have ajax request, then it have to initial the facebox again, this behaviour make the facebox bind function multiple times and cause multiple render the content.

test reproduce
just double

$('a[rel*=facebox]').facebox();
