### PR TITLE
Added overflow-y CSS autoscroll function

### DIFF
--- a/src/facebox.css
+++ b/src/facebox.css
@@ -19,7 +19,6 @@
 }
 
 #facebox .content {
-  display:table;
   width: 370px;
   padding: 10px;
   background: #fff;
@@ -38,7 +37,7 @@
 #facebox .close{
   position:absolute;
   top:5px;
-  right:5px;
+  right:17px;
   padding:2px;
   background:#fff;
 }

--- a/src/facebox.js
+++ b/src/facebox.js
@@ -84,6 +84,7 @@
     settings: {
       opacity      : 0.2,
       overlay      : true,
+      autoscroll   : true,
       loadingImage : '/facebox/loading.gif',
       closeImage   : '/facebox/closelabel.png',
       imageTypes   : [ 'png', 'jpg', 'jpeg', 'gif' ],
@@ -102,8 +103,14 @@
       if ($('#facebox .loading').length == 1) return true
       showOverlay()
 
-      $('#facebox .content').empty().
-        append('<div class="loading"><img src="'+$.facebox.settings.loadingImage+'"/></div>')
+      var content = $('#facebox .content')
+      content.empty().append('<div class="loading"><img src="'+$.facebox.settings.loadingImage+'"/></div>')
+      if ($.facebox.settings.autoscroll) {
+        content.css({
+          height: getPageHeight() - ((getPageHeight() / 10) * 2),
+          overflowY: 'auto'
+        })
+      }
 
       $('#facebox').show().css({
         top:	getPageScroll()[1] + (getPageHeight() / 10),


### PR DESCRIPTION
Added a new option called "autoscroll" (default: true). If this option is "true" facebox defines the height of the box dynamically and set CSS attribute 'overflow-y' to 'auto' on the content DIV. This is helpfull if very long text is loaded into the facebox and prevents the box for getting very very long.
