### PR TITLE
Add the custom class to the #facebox element so it can be targeted for styling.

### DIFF
--- a/src/facebox.js
+++ b/src/facebox.js
@@ -119,7 +119,7 @@
 
     reveal: function(data, klass) {
       $(document).trigger('beforeReveal.facebox')
-      if (klass) $('#facebox .content').addClass(klass)
+      if (klass) $('#facebox').addClass(klass).find('.content').addClass(klass)
       $('#facebox .content').empty().append(data)
       $('#facebox .popup').children().fadeIn('normal')
       $('#facebox').css('left', $(window).width() / 2 - ($('#facebox .popup').outerWidth() / 2))
@@ -303,7 +303,8 @@
     }
     $(document).unbind('keydown.facebox')
     $('#facebox').fadeOut(function() {
-      $('#facebox .content').removeClass().addClass('content')
+      $('#facebox').removeClass()
+        .find('.content').removeClass().addClass('content')
       $('#facebox .loading').remove()
       $(document).trigger('afterClose.facebox')
     })


### PR DESCRIPTION
I wanted to style the entire #facebox div with certain links, not just the .content subdiv, so I set it to add (and remove) the custom class to the #facebox div too.
