### PR TITLE
Fix a width bug

### DIFF
--- a/src/facebox.css
+++ b/src/facebox.css
@@ -8,6 +8,7 @@
 
 
 #facebox .popup{
+  padding: 0 20px 0 0;
   position:relative;
   border:3px solid rgba(0,0,0,0);
   -webkit-border-radius:5px;


### PR DESCRIPTION
As .content has a `padding: 10px`, the .popup div is not wide enough. This fix it.
